### PR TITLE
Refactor: Move Import Statement within Function

### DIFF
--- a/lnpay_py/__init__.py
+++ b/lnpay_py/__init__.py
@@ -1,6 +1,4 @@
-from .utility_helpers import post_request
-
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 __VERSION__ = 'py' + __version__
 __ENDPOINT_URL__ = 'https://api.lnpay.co/v1/'
@@ -35,4 +33,5 @@ def initialize(public_api_key, default_wak=None, params=None):
     __DEFAULT_WAK__ = default_wak
 
 def create_wallet(params):
+    from .utility_helpers import post_request
     return post_request('wallet', params)


### PR DESCRIPTION
Previously, the create_wallet function had an import statement that triggered the installation of the requests library, potentially causing issues in environments where requests was not pre-installed. To address this, I decided to refactor the code.